### PR TITLE
Remove deprecated ActionMailer deliver & deliver!

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove deprecated `deliver` and `deliver!` methods.
+
+    *claudiob*
+
 *   Template lookup now respects default locale and I18n fallbacks.
 
     Given the following templates:

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -85,26 +85,6 @@ module ActionMailer
       message.deliver
     end
 
-    def deliver! #:nodoc:
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        `#deliver!` is deprecated and will be removed in Rails 5. Use
-        `#deliver_now!` to deliver immediately or `#deliver_later!` to
-        deliver through Active Job.
-      MSG
-
-      deliver_now!
-    end
-
-    def deliver #:nodoc:
-      ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        `#deliver` is deprecated and will be removed in Rails 5. Use
-        `#deliver_now` to deliver immediately or `#deliver_later` to
-        deliver through Active Job.
-      MSG
-
-      deliver_now
-    end
-
     private
 
       def enqueue_delivery(delivery_method, options={})

--- a/actionmailer/test/message_delivery_test.rb
+++ b/actionmailer/test/message_delivery_test.rb
@@ -32,25 +32,6 @@ class MessageDeliveryTest < ActiveSupport::TestCase
     assert_equal Mail::Message , @mail.message.class
   end
 
-  test 'should respond to .deliver' do
-    assert_respond_to @mail, :deliver
-  end
-
-  test 'should respond to .deliver!' do
-    assert_respond_to @mail, :deliver!
-  end
-
-  test '.deliver is deprecated' do
-    assert_deprecated do
-      @mail.deliver
-    end
-  end
-  test '.deliver! is deprecated' do
-    assert_deprecated do
-      @mail.deliver!
-    end
-  end
-
   test 'should respond to .deliver_later' do
     assert_respond_to @mail, :deliver_later
   end


### PR DESCRIPTION
These methods were deprecated in Rails 4.2 (see f4ee1147) so they can be safely removed in Rails 5.0.
