### PR TITLE
Revise middleware deletion

### DIFF
--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -41,23 +41,6 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BazMiddleware, @stack.last.klass
   end
 
-  test "use should push middleware class with arguments onto the stack" do
-    assert_difference "@stack.size" do
-      @stack.use BazMiddleware, true, foo: "bar"
-    end
-    assert_equal BazMiddleware, @stack.last.klass
-    assert_equal([true, { foo: "bar" }], @stack.last.args)
-  end
-
-  test "use should push middleware class with block arguments onto the stack" do
-    proc = Proc.new {}
-    assert_difference "@stack.size" do
-      @stack.use(BlockMiddleware, &proc)
-    end
-    assert_equal BlockMiddleware, @stack.last.klass
-    assert_equal proc, @stack.last.block
-  end
-
   test "insert inserts middleware at the integer index" do
     @stack.insert(1, BazMiddleware)
     assert_equal BazMiddleware, @stack[1].klass
@@ -202,6 +185,88 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal BarMiddleware, @stack.first.klass
     assert_equal FooMiddleware, @stack[1].klass
     assert_equal QuxMiddleware, @stack[2].klass
+  end
+
+  test "use should push middleware class with arguments onto the stack" do
+    assert_difference "@stack.size" do
+      @stack.use BazMiddleware, true, foo: "bar"
+    end
+    assert_equal BazMiddleware, @stack.last.klass
+    assert_equal([true, { foo: "bar" }], @stack.last.args)
+  end
+
+  test "use should push middleware class with block arguments onto the stack" do
+    proc = Proc.new {}
+    assert_difference "@stack.size" do
+      @stack.use(BlockMiddleware, &proc)
+    end
+    assert_equal BlockMiddleware, @stack.last.klass
+    assert_equal proc, @stack.last.block
+  end
+
+  test "insert should handle arguments" do
+    @stack.insert(0, BazMiddleware, true, { foo: "bar" })
+    assert_equal BazMiddleware, @stack.first.klass
+    assert_equal([true, { foo: "bar" }], @stack.first.args)
+  end
+
+  test "insert should handle a block" do
+    proc = Proc.new {}
+    @stack.insert(0, BlockMiddleware, &proc)
+    assert_equal BlockMiddleware, @stack.first.klass
+    assert_equal proc, @stack.first.block
+  end
+
+  test "insert_before should handle arguments" do
+    @stack.insert_before(0, BazMiddleware, true, { foo: "bar" })
+    assert_equal BazMiddleware, @stack.first.klass
+    assert_equal([true, { foo: "bar" }], @stack.first.args)
+  end
+
+  test "insert_before should handle a block" do
+    proc = Proc.new {}
+    @stack.insert_before(0, BlockMiddleware, &proc)
+    assert_equal BlockMiddleware, @stack.first.klass
+    assert_equal proc, @stack.first.block
+  end
+
+  test "insert_after should handle arguments" do
+    @stack.insert_after(1, BazMiddleware, true, { foo: "bar" })
+    assert_equal BazMiddleware, @stack.last.klass
+    assert_equal([true, { foo: "bar" }], @stack.last.args)
+  end
+
+  test "insert_after should handle a block" do
+    proc = Proc.new {}
+    @stack.insert_after(1, BlockMiddleware, &proc)
+    assert_equal BlockMiddleware, @stack.last.klass
+    assert_equal proc, @stack.last.block
+  end
+
+  test "swap should handle arguments" do
+    @stack.swap(FooMiddleware, BazMiddleware, true, { foo: "bar" })
+    assert_equal BazMiddleware, @stack.first.klass
+    assert_equal([true, { foo: "bar" }], @stack.first.args)
+  end
+
+  test "swap should handle a block" do
+    proc = Proc.new {}
+    @stack.swap(FooMiddleware, BlockMiddleware, &proc)
+    assert_equal BlockMiddleware, @stack.first.klass
+    assert_equal proc, @stack.first.block
+  end
+
+  test "unshift should handle arguments" do
+    @stack.unshift(BazMiddleware, true, { foo: "bar" })
+    assert_equal BazMiddleware, @stack.first.klass
+    assert_equal([true, { foo: "bar" }], @stack.first.args)
+  end
+
+  test "unshift should handle a block" do
+    proc = Proc.new {}
+    @stack.unshift(BlockMiddleware, &proc)
+    assert_equal BlockMiddleware, @stack.first.klass
+    assert_equal proc, @stack.first.block
   end
 
 end

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -4,6 +4,7 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   class FooMiddleware; end
   class BarMiddleware; end
   class BazMiddleware; end
+  class QuxMiddleware; end
   class HiyaMiddleware; end
   class BlockMiddleware
     attr_reader :block
@@ -137,7 +138,7 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal false, @stack.include?(FooMiddleware)
   end
 
-  test "adds middleware right before the previous middleware of the deleted target" do
+  test "adds middleware right before the next middleware of the deleted target" do
     @stack.use BazMiddleware
     @stack.delete BarMiddleware
     @stack.insert_before BarMiddleware, HiyaMiddleware
@@ -156,4 +157,16 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     assert_equal HiyaMiddleware, @stack[2].klass
     assert_equal false, @stack.include?(BazMiddleware)
   end
+
+  test "adds relative to the original (deleted) location, not the new location" do
+    @stack.delete BarMiddleware
+    @stack.unshift BarMiddleware
+    @stack.insert_after BarMiddleware, QuxMiddleware
+
+    # Qux comes immediately after Bar's original location, not after Bar's new location
+    assert_equal BarMiddleware, @stack.first.klass
+    assert_equal FooMiddleware, @stack[1].klass
+    assert_equal QuxMiddleware, @stack[2].klass
+  end
+
 end


### PR DESCRIPTION
This is a suggested addendum to https://github.com/rails/rails/pull/27936

Specifically it addresses the issue mentioned here: https://github.com/rails/rails/pull/27936#issuecomment-278172033

It also restores previous behavior so that deleting a middleware deletes _all_ instances of the middleware in the stack, rather than just the first one.