### PR TITLE
Remove deprecation of `query_constraints:` association option, raise instead

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -523,9 +523,9 @@ module ActiveRecord
         @association_foreign_key = nil
         @association_primary_key = nil
         if options[:query_constraints]
-          ActiveRecord.deprecator.warn <<~MSG.squish
-            Setting `query_constraints:` option on `#{active_record}.#{macro} :#{name}` is deprecated.
-            To maintain current behavior, use the `foreign_key` option instead.
+          raise ConfigurationError, <<~MSG.squish
+            Setting `query_constraints:` option on `#{active_record}.#{macro} :#{name}` is not allowed.
+            To get the same behavior, use the `foreign_key` option instead.
           MSG
         end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -464,21 +464,21 @@ class AssociationsTest < ActiveRecord::TestCase
 
   def test_using_query_constraints_warns_about_changing_behavior
     has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::BlogPost.has_many :qc_deprecated_comments` is deprecated.
-      To maintain current behavior, use the `foreign_key` option instead.
+      Setting `query_constraints:` option on `Sharded::BlogPost.has_many :qc_deprecated_comments` is not allowed.
+      To get the same behavior, use the `foreign_key` option instead.
     MSG
 
-    assert_deprecated(has_many_expected_message, ActiveRecord.deprecator) do
+    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
       Sharded::BlogPost.has_many :qc_deprecated_comments,
         class_name: "Sharded::Comment", query_constraints: [:blog_id, :blog_post_id]
     end
 
     belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Sharded::Comment.belongs_to :qc_deprecated_blog_post` is deprecated.
-      To maintain current behavior, use the `foreign_key` option instead.
+      Setting `query_constraints:` option on `Sharded::Comment.belongs_to :qc_deprecated_blog_post` is not allowed.
+      To get the same behavior, use the `foreign_key` option instead.
     MSG
 
-    assert_deprecated(belongs_to_expected_message, ActiveRecord.deprecator) do
+    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
       Sharded::Comment.belongs_to :qc_deprecated_blog_post,
         class_name: "Sharded::Blog", query_constraints: [:blog_id, :blog_post_id]
     end

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -681,29 +681,29 @@ class ReflectionTest < ActiveRecord::TestCase
 
   def test_using_query_constraints_warns_about_changing_behavior
     has_many_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_many :clients` is deprecated.
-      To maintain current behavior, use the `foreign_key` option instead.
+      Setting `query_constraints:` option on `Firm.has_many :clients` is not allowed.
+      To get the same behavior, use the `foreign_key` option instead.
     MSG
 
-    assert_deprecated(has_many_expected_message, ActiveRecord.deprecator) do
+    assert_raises(ActiveRecord::ConfigurationError, match: has_many_expected_message) do
       ActiveRecord::Reflection.create(:has_many, :clients, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
     end
 
     has_one_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.has_one :account` is deprecated.
-      To maintain current behavior, use the `foreign_key` option instead.
+      Setting `query_constraints:` option on `Firm.has_one :account` is not allowed.
+      To get the same behavior, use the `foreign_key` option instead.
     MSG
 
-    assert_deprecated(has_one_expected_message, ActiveRecord.deprecator) do
+    assert_raises(ActiveRecord::ConfigurationError, match: has_one_expected_message) do
       ActiveRecord::Reflection.create(:has_one, :account, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
     end
 
     belongs_to_expected_message = <<~MSG.squish
-      Setting `query_constraints:` option on `Firm.belongs_to :client` is deprecated.
-      To maintain current behavior, use the `foreign_key` option instead.
+      Setting `query_constraints:` option on `Firm.belongs_to :client` is not allowed.
+      To get the same behavior, use the `foreign_key` option instead.
     MSG
 
-    assert_deprecated(belongs_to_expected_message, ActiveRecord.deprecator) do
+    assert_raises(ActiveRecord::ConfigurationError, match: belongs_to_expected_message) do
       ActiveRecord::Reflection.create(:belongs_to, :client, nil, { query_constraints: [:firm_id, :firm_name] }, Firm)
     end
   end


### PR DESCRIPTION
Deprecation was added in https://github.com/rails/rails/pull/51571 with the intention to change the behavior of `query_constraints:` option on associations.
    
The change is still intended to be implemented but was delayed to a future Rails version.
Meanwhile we would like applications to stop using `query_constraints:` option on associations.